### PR TITLE
Demo state reset between tests

### DIFF
--- a/runner/AndroidTestOrchestratorSample/app/build.gradle
+++ b/runner/AndroidTestOrchestratorSample/app/build.gradle
@@ -11,6 +11,7 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments clearPackageData: 'true'
     }
     buildTypes {
         release {

--- a/runner/AndroidTestOrchestratorSample/app/src/main/java/com/example/android/testing/androidtestorchestratorsample/CalculatorActivity.java
+++ b/runner/AndroidTestOrchestratorSample/app/src/main/java/com/example/android/testing/androidtestorchestratorsample/CalculatorActivity.java
@@ -31,6 +31,7 @@ import android.widget.TextView;
  * operation {@link Button}s at the bottom.
  */
 public class CalculatorActivity extends Activity {
+    private static boolean isFirstLaunch = true;
 
     private static final String TAG = "CalculatorActivity";
 
@@ -49,6 +50,10 @@ public class CalculatorActivity extends Activity {
         mResultTextView = (TextView) findViewById(R.id.operation_result_text_view);
         mOperandOneEditText = (EditText) findViewById(R.id.operand_one_edit_text);
         mOperandTwoEditText = (EditText) findViewById(R.id.operand_two_edit_text);
+        if (!isFirstLaunch) {
+            finish();
+        }
+        isFirstLaunch = false;
     }
 
     /**


### PR DESCRIPTION
make test fail if state is persisted between tests.
Test Orchestrator starts test in new process and static field is not persisted between tests.
Removing the following will make the tests fail:
```
testOptions {
        execution 'ANDROIDX_TEST_ORCHESTRATOR'
    }
``` 